### PR TITLE
Implemented proxy methods for adding/removing client to/from groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
+## <next>
+* Implemented methods in hub proxy for adding and removing clients to and from named groups
+
 ## 3.0.0
 * injectSignalR can now be used as a decorator (contains breaking changes)
 * Superficial code restructuring, linter fixes, etc.

--- a/src/types.jsx
+++ b/src/types.jsx
@@ -5,6 +5,8 @@ const { func } = PropTypes;
 const hubShape = PropTypes.shape({
   invoke: func.isRequired,
   send: func.isRequired,
+  add: func.isRequired,
+  remove: func.isRequired,
   register: func.isRequired,
   unregister: func.isRequired,
 });


### PR DESCRIPTION
If we would use controller requests to manage clients' groups, we would have to require an implementation of a separate cache for pairs of clients and connections in the server-side service context, because hub doesn't provide connection id's. However, as this pairing is already done "under-the-hood" in SignalR, it is more reasonable to require just an implementation of named methods in the hub for managing clients' groups.

Also moved the examples in README around a bit while adding documentation for add and remove proxy methods.